### PR TITLE
poggit builds is no longer working.

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -1,5 +1,5 @@
 --- # Open the ProfanityFilter CI at https://poggit.pmmp.io/ci/ReinfyTeam/ProfanityFilter
-build-by-default: true
+build-by-default: false
 branches:
 - stable 
 projects:


### PR DESCRIPTION
You can download latest phar build on github action tab, and click latest build, then download the artifact.